### PR TITLE
Add tispark notebook container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /docker/dashboard_installer/dashboard/tidb.json
 /docker/dashboard_installer/dashboard/tikv.json
 /.idea
+/notebook/metastore_db
+/notebook/derby.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,38 @@ services:
     depends_on:
       - tispark-master
     restart: on-failure
-
+  tispark-slave1:
+    image: pingcap/tispark:latest
+    command:
+      - /opt/spark/sbin/start-slave.sh
+      - spark://tispark-master:7077
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+    environment:
+      SPARK_WORKER_WEBUI_PORT: 38082
+    ports:
+      - "38082:38082"
+    depends_on:
+      - tispark-master
+    restart: on-failure
+  
+  tispark-notebook:
+    image: pingcap/tispark-notebook:latest
+    build: tispark-notebook
+    volumes:
+      - ./notebook:/home/tispark/notebook
+      - ./config/spark-defaults.conf:/usr/lib/python2.7/site-packages/pyspark/conf/spark-defaults.conf:ro
+    environment:
+      SPARK_DRIVER_MEMORY: 6G
+      SPARK_EXECUTOR_MEMORY: 6G
+      SPARK_EXECUTOR_CORES: 3
+      MASTER: spark://tispark-master:7077
+    ports:
+      - "4445:4445"
+    depends_on:
+      - "tispark-master"
+    restart: on-failure
+  
   tidb-vision:
     image: pingcap/tidb-vision:latest
     environment:

--- a/notebook/Demo.ipynb
+++ b/notebook/Demo.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pyspark.context.SparkContext at 0x7fb7f7fe9f90>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------+\n",
+      "|count(1)|\n",
+      "+--------+\n",
+      "|       1|\n",
+      "+--------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pytispark.pytispark as pti\n",
+    " \n",
+    "ti = pti.TiContext(spark)\n",
+    " \n",
+    "ti.tidbMapDatabase(\"mysql\")\n",
+    " \n",
+    "sql(\"select count(*) from user\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.1424416\n",
+      "CPU times: user 10 ms, sys: 10 ms, total: 20 ms\n",
+      "Wall time: 2.17 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import random\n",
+    "num_samples = 10000000\n",
+    "def inside(p):     \n",
+    "  x, y = random.random(), random.random()\n",
+    "  return x*x + y*y < 1\n",
+    "\n",
+    "count = sc.range(0, num_samples).filter(inside).count()\n",
+    "pi = 4.0 * count / num_samples\n",
+    "print(pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.1413576\n",
+      "CPU times: user 3.91 s, sys: 160 ms, total: 4.07 s\n",
+      "Wall time: 4.13 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import random\n",
+    "num_samples = 10000000\n",
+    "def inside(p):     \n",
+    "  x, y = random.random(), random.random()\n",
+    "  return x*x + y*y < 1\n",
+    "\n",
+    "itr = filter(inside, range(0, num_samples))\n",
+    "pi = 4.0 * sum(1 for _ in itr)/num_samples\n",
+    "print(pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.stop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tispark-notebook/Dockerfile
+++ b/tispark-notebook/Dockerfile
@@ -1,0 +1,33 @@
+FROM anapsix/alpine-java:8
+
+ENV SPARK_VERSION=2.1.1 \
+    HADOOP_VERSION=2.7 \
+    TISPARK_VERSION=0.1.0-SNAPSHOT \
+    USER_HOME=/home/tispark \
+    SPARK_HOME=/usr/lib/python2.7/site-packages/pyspark \
+    SPARK_NO_DAEMONIZE=true \
+    SPARK_DRIVER_MEMORY=2G \
+    SPARK_EXECUTOR_MEMORY=2G \
+    SPARK_EXECUTOR_CORES=3 \
+    MASTER=spark://tispark-master:7077 \
+    PYSPARK_DRIVER_PYTHON=jupyter \
+    PYSPARK_DRIVER_PYTHON_OPTS='notebook --ip=0.0.0.0 --port=4445 --no-browser --notebook-dir=./notebook'
+
+# base image only contains busybox version nohup and ps
+# spark scripts needs nohup in coreutils and ps in procps
+# and we can use mysql-client to test tidb connection
+RUN apk --no-cache add coreutils procps mysql-client python python-dev py-pip alpine-sdk \
+    && pip install jupyter pytispark \
+    && wget -q http://download.pingcap.org/tispark-${TISPARK_VERSION}-jar-with-dependencies.jar -P ${SPARK_HOME}/jars \
+    && adduser -D -u 1000 tispark
+
+USER tispark
+
+WORKDIR ${USER_HOME}
+
+RUN mkdir -p /home/tispark/notebook \
+    && jupyter notebook --generate-config
+
+ADD jupyter_notebook_config.json ${USER_HOME}/.jupyter/jupyter_notebook_config.json
+
+ENTRYPOINT ["pyspark"]

--- a/tispark-notebook/jupyter_notebook_config.json
+++ b/tispark-notebook/jupyter_notebook_config.json
@@ -1,0 +1,5 @@
+{
+  "NotebookApp": {
+    "password": "sha1:4e1c2ed53526:58a3895a278ebd043c2440504a76317600154f41"
+  }
+}


### PR DESCRIPTION
So after `docker-compose up -d`, one can simply visit `localhost:4445` and use the notebook to test TiSpark out. (Login password is admin)

It looks like this:
![image](https://user-images.githubusercontent.com/161689/42729100-62c6c27a-87cd-11e8-89fa-9b27436465af.png)
